### PR TITLE
Allowing numeric values in menu slug regexp

### DIFF
--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -44,7 +44,7 @@ add_action( 'rest_api_init', function () {
         'callback' => 'wp_api_v2_menus_get_all_menus',
     ) );
 
-    register_rest_route( 'menus/v1', '/menus/(?P<id>[a-zA-Z(-]+)', array(
+    register_rest_route( 'menus/v1', '/menus/(?P<id>[a-zA-Z0-9(-]+)', array(
         'methods' => 'GET',
         'callback' => 'wp_api_v2_menus_get_menu_data',
     ) );


### PR DESCRIPTION
Firstly, thank you for putting this library together.

I have been making use of it for a project, and I ran into an issue. I have menu slugs that include numbers (footer-col1-menu, for example), and was getting 404s when attempting to query for them. This pull request fixes that issue.

Cheers,

Josh