### PR TITLE
Allow underscore to slug regexp

### DIFF
--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -44,7 +44,7 @@ add_action( 'rest_api_init', function () {
         'callback' => 'wp_api_v2_menus_get_all_menus',
     ) );
 
-    register_rest_route( 'menus/v1', '/menus/(?P<id>[a-zA-Z0-9(-]+)', array(
+    register_rest_route( 'menus/v1', '/menus/(?P<id>[a-zA-Z0-9_-]+)', array(
         'methods' => 'GET',
         'callback' => 'wp_api_v2_menus_get_menu_data',
     ) );


### PR DESCRIPTION
I have a theme which, curiously, uses underscores (e.g. `bingo_ruby_menu_offcanvas`) for the menu slugs rather than dashes, and trying to query those gives me 404s. This PR adds the underscore character to the regular expression matching the menu slug.