### PR TITLE
Thumbnail src for childs items

### DIFF
--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -145,13 +145,6 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 			// add slug to menu items
 			$slug = basename( get_permalink($item->object_id) );
 			$item->slug = $slug;
-			if (isset($item->thumbnail_id) && $item->thumbnail_id) {
-				$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
-			}
-			if (isset($item->thumbnail_hover_id) && $item->thumbnail_hover_id) {
-				$item->thumbnail_hover_src = wp_get_attachment_image_url(intval($item->thumbnail_hover_id), 'post-thumbnail');
-			}
-
 		} else if($item->type == 'taxonomy') {
 			$cat = get_term($item->object_id);
 			$item->slug = $cat->slug;
@@ -163,17 +156,18 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 			}
 		}
 
-		if ( $item->menu_item_parent ) {
-			if (isset($item->thumbnail_id) && $item->thumbnail_id) {
-				$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
-			}
-			if (isset($item->thumbnail_hover_id) && $item->thumbnail_hover_id) {
-				$item->thumbnail_hover_src = wp_get_attachment_image_url(intval($item->thumbnail_hover_id), 'post-thumbnail');
-			}
+		if (isset($item->thumbnail_id) && $item->thumbnail_id) {
+			$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
+		}
+		if (isset($item->thumbnail_hover_id) && $item->thumbnail_hover_id) {
+			$item->thumbnail_hover_src = wp_get_attachment_image_url(intval($item->thumbnail_hover_id), 'post-thumbnail');
+		}
 
+		if ( $item->menu_item_parent ) {
 			array_push( $child_items, $item );
 			unset( $menu_items[ $key ] );
 		}
+
 	}
 
 	// push child items into their parent item in the original object

--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -148,6 +148,10 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 			if (isset($item->thumbnail_id) && $item->thumbnail_id) {
 				$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
 			}
+			if (isset($item->thumbnail_hover_id) && $item->thumbnail_hover_id) {
+				$item->thumbnail_hover_src = wp_get_attachment_image_url(intval($item->thumbnail_hover_id), 'post-thumbnail');
+			}
+
 		} else if($item->type == 'taxonomy') {
 			$cat = get_term($item->object_id);
 			$item->slug = $cat->slug;
@@ -162,6 +166,9 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 		if ( $item->menu_item_parent ) {
 			if (isset($item->thumbnail_id) && $item->thumbnail_id) {
 				$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
+			}
+			if (isset($item->thumbnail_hover_id) && $item->thumbnail_hover_id) {
+				$item->thumbnail_hover_src = wp_get_attachment_image_url(intval($item->thumbnail_hover_id), 'post-thumbnail');
 			}
 
 			array_push( $child_items, $item );

--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WP-REST-API V2 Menus
-Version: 0.7.3
+Version: 0.7.6
 Description: Adding menus endpoints on WP REST API v2
 Author: Claudio La Barbera
 Author URI: https://thebatclaud.io
@@ -146,10 +146,10 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 			$slug = basename( get_permalink($item->object_id) );
 			$item->slug = $slug;
 			if (isset($item->thumbnail_id) && $item->thumbnail_id) {
-				$item->thumbnailSrc = wp_get_attachment_image_url($item->thumbnail_id, 'post-thumbnail');
+				$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
 			}
 		} else if($item->type == 'taxonomy') {
-			$cat = get_category($item->object_id);
+			$cat = get_term($item->object_id);
 			$item->slug = $cat->slug;
 		} else if($item->type == 'post_type_archive') {
 			$post_type_data = get_post_type_object($item->object);
@@ -160,6 +160,10 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 		}
 
 		if ( $item->menu_item_parent ) {
+			if (isset($item->thumbnail_id) && $item->thumbnail_id) {
+				$item->thumbnail_src = wp_get_attachment_image_url(intval($item->thumbnail_id), 'post-thumbnail');
+			}
+
 			array_push( $child_items, $item );
 			unset( $menu_items[ $key ] );
 		}


### PR DESCRIPTION
1. I changed case from thumbnailSrc to thumbnail_src, as WP uses this case
2. I added thumbnail_src for child_items (as I need it in my current project)
3. I added thumbnail_hover_src which bases on thumbnail_hover_id