### PR TITLE
Fixed changes to `register_rest_route` signature for WP 5.5

### DIFF
--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -226,24 +226,24 @@ add_action( 'rest_api_init', function () {
 	register_rest_route( 'menus/v1', '/menus', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_menus_get_all_menus',
-    'permission_callback' => '__return_true'
+		'permission_callback' => '__return_true'
 	) );
 
 	register_rest_route( 'menus/v1', '/menus/(?P<id>[a-zA-Z0-9_-]+)', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_menus_get_menu_data',
-    'permission_callback' => '__return_true'
+		'permission_callback' => '__return_true'
 	) );
 
 	register_rest_route( 'menus/v1', '/locations/(?P<id>[a-zA-Z0-9_-]+)', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_locations_get_menu_data',
-    'permission_callback' => '__return_true'
+		'permission_callback' => '__return_true'
 	) );
 
 	register_rest_route( 'menus/v1', '/locations', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_menu_get_all_locations',
-    'permission_callback' => '__return_true'
+		'permission_callback' => '__return_true'
 	) );
 } );

--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -226,20 +226,24 @@ add_action( 'rest_api_init', function () {
 	register_rest_route( 'menus/v1', '/menus', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_menus_get_all_menus',
+    'permission_callback' => '__return_true'
 	) );
 
 	register_rest_route( 'menus/v1', '/menus/(?P<id>[a-zA-Z0-9_-]+)', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_menus_get_menu_data',
+    'permission_callback' => '__return_true'
 	) );
 
 	register_rest_route( 'menus/v1', '/locations/(?P<id>[a-zA-Z0-9_-]+)', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_locations_get_menu_data',
+    'permission_callback' => '__return_true'
 	) );
 
 	register_rest_route( 'menus/v1', '/locations', array(
 		'methods'  => 'GET',
 		'callback' => 'wp_api_v2_menu_get_all_locations',
+    'permission_callback' => '__return_true'
 	) );
 } );


### PR DESCRIPTION
Changes in WP 5.5 were throwing notices in admin before the start of the document. Added `permission_callback` to fix.
This fixes issue #34