### PR TITLE
Use post_name instead of basename (Bugfix for static home page)

### DIFF
--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -157,7 +157,7 @@ function wp_api_v2_menus_get_menu_items( $id ) {
 
 		if($item->type == 'post_type') {
 			// add slug to menu items
-			$slug = basename( get_permalink($item->object_id) );
+			$slug = get_post_field( 'post_name', $item->object_id );
 			$item->slug = $slug;
 		} else if($item->type == 'taxonomy') {
 			$cat = get_term($item->object_id);


### PR DESCRIPTION
Fixes Bug when setting a static front-page.

Context on localhost: When setting a static frontpage `basename( get_sl($item->object_id) )` returns "localhost". Using `et_post_field( 'post_name', $item->object_id )` returns the actual slug of the page.