### PR TITLE
Fix fatal error issue when menu term is missing

### DIFF
--- a/wp-rest-api-v2-menus.php
+++ b/wp-rest-api-v2-menus.php
@@ -67,7 +67,12 @@ function wp_api_v2_locations_get_menu_data( $data ) {
 	// this could be replaced with `if (has_nav_menu($data['id']))`
 	if ( ( $locations = get_nav_menu_locations() ) && isset( $locations[ $data['id'] ] ) ) {
 		// Replace default empty object with the location object
-		$menu        = get_term( $locations[ $data['id'] ] );
+		$menu = get_term( $locations[ $data['id'] ] );
+
+		if ( is_wp_error( $menu ) || null === $menu ) {
+			return new WP_Error( 'not_found', 'No location has been found with this id or slug: `' . $data['id'] . '`. Please ensure you passed an existing location ID or location slug.', array( 'status' => 404 ) );
+		}
+
 		$menu->items = wp_api_v2_menus_get_menu_items( $locations[ $data['id'] ] );
 	} else {
 		return new WP_Error( 'not_found', 'No location has been found with this id or slug: `' . $data['id'] . '`. Please ensure you passed an existing location ID or location slug.', array( 'status' => 404 ) );


### PR DESCRIPTION
This fixes #43 by checking whether a `WP_Term` object has been returned before assigning the `items` property.

If a `WP_Error` or `null` is returned, we return the 404 error, as there is no nav term for that slug, despite it existing in the theme mods.